### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,12 @@ updates:
     commit-message:
       prefix: "docker"
       include: "scope"
+    ignore:
+      - dependency-name: "python"
+        versions: ["3.13.x", "4.x"]  # Ignore pre-release and major versions
+    allow:
+      - dependency-name: "python"
+        dependency-type: "direct"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
# Summary

1. Ignore Python 3.13.x and 4.x versions in Docker updates
2. Only allow direct dependency updates for Python
3. Maintain the existing weekly schedule and labeling

This will prevent future pull requests for pre-release Python versions while still allowing stable version updates. The configuration change will take effect as soon as it's committed to your repository.